### PR TITLE
jenkins-zh#93 fix sort by date and reorganize form

### DIFF
--- a/layouts/meetup/list.html
+++ b/layouts/meetup/list.html
@@ -32,8 +32,9 @@
   <table width="1000px">
     <thead>
       <tr>
+        <th>时间</th>
+        <th>主题</th>
         <th>城市</th>
-        <th>主题/日期</th>
         <th>位置</th>
         <th>状态</th>
         <th>赞助</th>
@@ -41,13 +42,11 @@
     </thead>
     <tbody>
       <!-- should use hostDate instead of order, but cannot get the right order by hostDate -->
-      {{ range (sort .Pages ".Params.order" "desc") }}
+      {{ range (sort .Pages ".Params.hostdate" "desc") }}
       <tr>
+        <td>{{ with .Params.hostDate }}{{ . }}{{ else }}待定{{ end }}</td>
+        <td>{{ with .Params.topic }}{{ . }}{{ else }}待定{{ end }}</br></td>
         <td>{{ .Params.city }}</td>
-        <td>
-          {{ with .Params.topic }}{{ . }}{{ else }}待定{{ end }}</br>
-          {{ with .Params.hostDate }}{{ . }}{{ else }}待定{{ end }}
-        </td>
         <td>
           {{ if ne .Params.location "" }}
           {{ if ne .Params.map "" }}<a target="_blank" href="{{.Params.map}}">{{.Params.location}}</a>{{else}}{{.Params.location}}{{ end }}


### PR DESCRIPTION
做了两处修改，请查看，提意见。

1. 现在按照时间可以排序了。原因是hugo 有个bug https://github.com/gohugoio/hugo/issues/6036 目前不支持 `.Params.hostDate` 只能小写 `.Params.hostdate`
2. 重新组织了这个表单，如下：

![fix sort2](https://user-images.githubusercontent.com/3353385/62944022-66801380-be0e-11e9-9049-50bfafe85dd0.png)